### PR TITLE
Réglé bug d'installation automatique et mis à jours le README en conséquence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-icsToJson/.env
+converter/feeds.txt
 .env

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ cd dockerStackCalendrier
 
 cp .env.example .env
 
-# Éditez `.env` avec vos valeurs (ex. `NEXTCLOUD_HOST`, `DB_PASSWORD`, etc.)
-
 nano .env
+
+# Éditez `.env` avec vos valeurs (ex. `NEXTCLOUD_HOST`, `DB_PASSWORD`, etc.)
+# Il est important que vous preniez note du nom d'usager et du mot de 
+#   passe administrateur NextCloud, car vous en aurez besoin à la prochaine étape
 
 ```
 
@@ -87,12 +89,12 @@ docker-compose up -d --build
 
 ```
 
-4. Accéder à l'interface web de Nextcloud pour finaliser l'installation.
+5. Ouvrez l'interface NextCloud sur votre navigateur web en entrant l'adresse suivante : `http://localhost:8080/`
 
-example: 
-port 8080 --> http://localhost:8080 (nextcloud)
-port 8081 --> http://localhost:8081 (Calendrier des Assos)
-
+6. Enregistrez-vous en tant qu'administrateur avec les identifiants de l'étape 2
+7. Cliquez sur l'icône de votre compte administrateur, puis sur "ajouter des applications"
+8. Installez l'application "Agenda"
+9. Visitez le calendrier des élèves avec l'URL suivante : `http://localhost:8081/`
 ---
 
 ## comment ajouter un association en tant qu'utilisateur nextcloud

--- a/converter/feeds.txt
+++ b/converter/feeds.txt
@@ -1,1 +1,1 @@
-REI=http://nextcloud/remote.php/dav/public-calendars/6DgT6EEg8oB8LEFM?export
+REI=http://nextcloud/remote.php/dav/public-calendars/EbgMepWgywtxQQ3o?export

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     volumes:
       - nextcloud_data:/var/www/html
       - "./vendor:/vendor:ro"
-      - "./scripts/initialize.sh:/docker-entrypoint-init.d/initialize.sh:ro"
+      - "./scripts/initialize.sh:/docker-entrypoint-hooks.d/before-starting/initialize.sh:ro"
     networks:
       - web
 

--- a/scripts/initialize.sh
+++ b/scripts/initialize.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+echo "!! === INITIALIZE.SH DEBUT === !!"
 set -eu
 
 # wait for DB


### PR DESCRIPTION
Lorsque d'autres développeurs tentent de build le projet, le calendrier des étudiants se retrouve incapable de se synchroniser avec le calendrier des asso.

Ceci est dû au fait que le script `scripts/initialization.sh` n'est pas exécuté. Ce script modifie les `trusted_domains` de NextCloud, ce qui permet au calendrier des étudiants de venir télécharger l'information de NextCloud.

Afin d'y remédier, j'ai modifié la configuration docker-compose.yml afin que le script soit monté sur `/docker-entrypoint-hooks.d/before-start/` au lieu de `docker-entrypoint-init.d/`.

Ceci a permit au script de s'exécuter, cependant NexCloud n'était pas encore installé, puisqu'il attendait la création du compte admin (jusqu'alors opération manuelle), ce qui empêchait la modification des `trusted_domains`.

Afin d'y remédier, j'ai ajouté les lignes suivantes à `.env` : 
```
NEXTCLOUD_ADMIN_USER="ADMIN"
NEXTCLOUD_ADMIN_PASSWORD="devdbpass123!"
```
Ce qui permet la création automatique d'un compte administrateur et l'installation de NextCloud.

Finalement, j'ai mis à jour le README pour refléter les nouvelles étapes d'installation.